### PR TITLE
Add participaciones section

### DIFF
--- a/index.html
+++ b/index.html
@@ -22,6 +22,9 @@
         <section id="step-2" class="wizard-step">
           <!-- Sección de exhibición internacional -->
         </section>
+        <section id="step-3" class="wizard-step">
+          <!-- Sección de participaciones -->
+        </section>
       </div>
       <div class="wizard-buttons">
         <button type="button" id="prev-btn" class="btn" disabled>Atrás</button>


### PR DESCRIPTION
## Summary
- add third wizard section for participaciones
- load roles from `rol.json` and allow multiple participations
- validate percentages per role and store step3 data
- show step3 in wizard flow

## Testing
- `node -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68858a1237d883278eed6b3591aef92b